### PR TITLE
Revert Capacity Block Hack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@
 // you may also need to run `make push-build-image` depending on what has changed
 module github.com/weaveworks/eksctl
 
-go 1.21
+go 1.22
+
 toolchain go1.22.2
 
 require (

--- a/pkg/cfn/builder/managed_launch_template.go
+++ b/pkg/cfn/builder/managed_launch_template.go
@@ -34,9 +34,6 @@ func (m *ManagedNodeGroupResourceSet) makeLaunchTemplateData(ctx context.Context
 				CapacityReservationResourceGroupArn: valueOrNil(mng.CapacityReservation.CapacityReservationTarget.CapacityReservationResourceGroupARN),
 			}
 		}
-		tmp := "capacity-block"
-		launchTemplateData.InstanceMarketOptions = &gfnec2.LaunchTemplate_InstanceMarketOptions{}
-		launchTemplateData.InstanceMarketOptions.MarketType = valueOrNil(&tmp)
 	}
 
 	userData, err := m.bootstrapper.UserData()

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -473,9 +473,6 @@ func newLaunchTemplateData(ctx context.Context, n *NodeGroupResourceSet) (*gfnec
 				CapacityReservationResourceGroupArn: valueOrNil(ng.CapacityReservation.CapacityReservationTarget.CapacityReservationResourceGroupARN),
 			}
 		}
-		tmp := "capacity-block"
-		launchTemplateData.InstanceMarketOptions = &gfnec2.LaunchTemplate_InstanceMarketOptions{}
-		launchTemplateData.InstanceMarketOptions.MarketType = valueOrNil(&tmp)
 	}
 
 	if err := buildNetworkInterfaces(ctx, launchTemplateData, ng.InstanceTypeList(), api.IsEnabled(ng.EFAEnabled), n.securityGroups, n.ec2API); err != nil {


### PR DESCRIPTION
- **Fix merge from main**
- **Revert capacity-block hack**

### Description

Revert `capacity-block` hack due to the fact that when capacity block reservations are not used, and on-demand capacity reservations are available, it generates the following error in CloudFormation:

```
   Resource handler returned message: "You must use a valid fully-formed launch template. The market type (purchasing) option is not valid. Choose a different market type and try again (Service: AutoScaling, Status Code: 400, Request ID: 4506edbb-da90-435c-842c-ea06cceb3c0f)" (RequestToken: b47abf27-7560-0ffe-0e4c-d7091fa935dd, HandlerErrorCode: InvalidRequest)
```


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

